### PR TITLE
Fix: setState() called after dispose() ... again

### DIFF
--- a/lib/show_fps.dart
+++ b/lib/show_fps.dart
@@ -172,6 +172,8 @@ class ShowFPSState extends State<ShowFPS> with SingleTickerProviderStateMixin {
 
   /// Updates the FPS counter with the current frame duration.
   void update(Duration duration) {
+    if(!mounted) return;
+    
     _frameCounter++;
 
     if (_frameCounter % widget.sampleRate == 0) {


### PR DESCRIPTION
# Pull Request

**Description**

Fix: setState() called after dispose(). This was already resolved in #3, but was reintroduced with release v1.1.0 (1d7c19e)

**Related Issue**

Reopens #3

By submitting this pull request, I confirm that my contribution is made under the project's [license](LICENSE).
